### PR TITLE
Update baroclinic.py

### DIFF
--- a/oceanmodes/baroclinic.py
+++ b/oceanmodes/baroclinic.py
@@ -68,7 +68,7 @@ def neutral_modes_from_N2_profile(z, N2, f0, depth=None, **kwargs):
         ----------
         z : array_like
             The depths at which N2 is given. Starts shallow, increases
-            positive downward.
+            positive downward. 
         N2 : array_like
             The squared buoyancy frequency (units s^-2). Points below topography
             should be masked or nan.
@@ -117,6 +117,8 @@ def _neutral_modes_from_N2_profile_raw(z, N2, f0, depth=None, **kwargs):
     # make sure z is increasing
     if not np.all(dzc > 0):
         raise ValueError('z should be monotonically increasing')
+    if z[1]==0:
+        raise ValueError('z[0] should not be 0, as it is the depth where N2 (a gradient quantity) is defined')
     if depth is None:
         depth = z[-1] + dzc[-1]/2
     else:


### PR DESCRIPTION
Added error message for the case when Z[0] =0, which cannot be a point at which N2 (a gradient quantity) is calculated/defined.